### PR TITLE
[BE-25] left Join -> innerJoin

### DIFF
--- a/src/main/java/com/bid/idearush/domain/idea/repository/IdeaRepositoryCustomImpl.java
+++ b/src/main/java/com/bid/idearush/domain/idea/repository/IdeaRepositoryCustomImpl.java
@@ -43,7 +43,7 @@ public class IdeaRepositoryCustomImpl extends QuerydslRepositorySupport implemen
                 ))
                 .where(qIdea.id.eq(ideaId))
                 .from(qIdea)
-                .leftJoin(qIdea.users, qUsers)
+                .innerJoin(qIdea.users, qUsers)
                 .fetchOne());
     }
 
@@ -59,17 +59,12 @@ public class IdeaRepositoryCustomImpl extends QuerydslRepositorySupport implemen
                         qIdea.bidWinPrice
                 ))
                 .from(qIdea)
-                .leftJoin(qIdea.users, qUsers)
+                .innerJoin(qIdea.users, qUsers)
                 .orderBy(qIdea.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
-//        JPAQuery<Long> count = queryFactory
-//                .select(qIdea.id)
-//                .from(qIdea);
-//
-//        long dataSize = count.fetchCount();
         return new PageImpl<>(results, pageable, count);
     }
 
@@ -89,17 +84,12 @@ public class IdeaRepositoryCustomImpl extends QuerydslRepositorySupport implemen
                         ideaCategoryEq(category)
                 )
                 .from(qIdea)
-                .leftJoin(qIdea.users, qUsers)
+                .innerJoin(qIdea.users, qUsers)
                 .orderBy(qIdea.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
-//        JPAQuery<Long> count = queryFactory
-//                .select(qIdea.id)
-//                .from(qIdea);
-//
-//        long dataSize = count.fetchCount();
         return new PageImpl<>(results, pageable, count);
     }
 


### PR DESCRIPTION
## 요약
아이디어 테이블과 유저 테이블의 연결이 되어 있기 때문에 innerJoin 으로 변경
왜냐하면 LEFT JOIN은 일치하지 않는 오른쪽 테이블의 컬럼에 대해 NULL 값을 반환합니다. 이 NULL 값들은 결과 셋에서 추가적인 처리나 메모리를 필요로 할 수 있으므로 innberJoin 으로 변경.

## 작업한 내용
- left Join -> innerJoin

## 핵심 코드 리뷰 요청
- 코드 리뷰 부탁드립니다.